### PR TITLE
test: sort connections for reproducibility

### DIFF
--- a/tarjan_test.go
+++ b/tarjan_test.go
@@ -17,6 +17,8 @@ package tarjan
 
 import (
 	"fmt"
+	"reflect"
+	"sort"
 	"testing"
 )
 
@@ -31,30 +33,16 @@ func TestTypeString(t *testing.T) {
 	graph["7"] = []interface{}{"6"}
 	graph["8"] = []interface{}{"5", "7", "8"}
 
-	output := Connections(graph)
-	if output[0][0] != "3" {
-		t.FailNow()
+	o := Connections(graph)
+	output := sortConnections(o)
+	exp := [][]string{
+		[]string{"1", "2", "3"},
+		[]string{"6", "7"},
+		[]string{"4", "5"},
+		[]string{"8"},
 	}
-	if output[0][1] != "2" {
-		t.FailNow()
-	}
-	if output[0][2] != "1" {
-		t.FailNow()
-	}
-	if output[1][0] != "7" {
-		t.FailNow()
-	}
-	if output[1][1] != "6" {
-		t.FailNow()
-	}
-	if output[2][0] != "5" {
-		t.FailNow()
-	}
-	if output[2][1] != "4" {
-		t.FailNow()
-	}
-	if output[3][0] != "8" {
-		t.FailNow()
+	if !reflect.DeepEqual(output, exp) {
+		t.Fatalf("FAIL.\nexp=%v\ngot=%v\n", exp, output)
 	}
 }
 
@@ -69,30 +57,16 @@ func TestTypeInt(t *testing.T) {
 	graph[7] = []interface{}{6}
 	graph[8] = []interface{}{5, 7, 8}
 
-	output := Connections(graph)
-	if output[0][0] != 3 {
-		t.FailNow()
+	o := Connections(graph)
+	output := sortConnections(o)
+	exp := [][]string{
+		[]string{"1", "2", "3"},
+		[]string{"6", "7"},
+		[]string{"4", "5"},
+		[]string{"8"},
 	}
-	if output[0][1] != 2 {
-		t.FailNow()
-	}
-	if output[0][2] != 1 {
-		t.FailNow()
-	}
-	if output[1][0] != 7 {
-		t.FailNow()
-	}
-	if output[1][1] != 6 {
-		t.FailNow()
-	}
-	if output[2][0] != 5 {
-		t.FailNow()
-	}
-	if output[2][1] != 4 {
-		t.FailNow()
-	}
-	if output[3][0] != 8 {
-		t.FailNow()
+	if !reflect.DeepEqual(output, exp) {
+		t.Fatalf("FAIL.\nexp=%v\ngot=%v\n", exp, output)
 	}
 }
 
@@ -107,30 +81,16 @@ func TestTypeMixed(t *testing.T) {
 	graph[7] = []interface{}{"6"}
 	graph[8] = []interface{}{5, 7, 8}
 
-	output := Connections(graph)
-	if output[0][0] != "3" {
-		t.FailNow()
+	o := Connections(graph)
+	output := sortConnections(o)
+	exp := [][]string{
+		[]string{"1", "2", "3"},
+		[]string{"6", "7"},
+		[]string{"4", "5"},
+		[]string{"8"},
 	}
-	if output[0][1] != 2 {
-		t.FailNow()
-	}
-	if output[0][2] != 1 {
-		t.FailNow()
-	}
-	if output[1][0] != 7 {
-		t.FailNow()
-	}
-	if output[1][1] != "6" {
-		t.FailNow()
-	}
-	if output[2][0] != 5 {
-		t.FailNow()
-	}
-	if output[2][1] != 4 {
-		t.FailNow()
-	}
-	if output[3][0] != 8 {
-		t.FailNow()
+	if !reflect.DeepEqual(output, exp) {
+		t.Fatalf("FAIL.\nexp=%v\ngot=%v\n", exp, output)
 	}
 }
 
@@ -147,7 +107,8 @@ func TestSingleVertex(t *testing.T) {
 	graph := make(map[interface{}][]interface{})
 	graph["1"] = []interface{}{}
 
-	output := Connections(graph)
+	o := Connections(graph)
+	output := sortConnections(o)
 	if output[0][0] != "1" {
 		t.FailNow()
 	}
@@ -157,7 +118,8 @@ func TestSingleVertexLoop(t *testing.T) {
 	graph := make(map[interface{}][]interface{})
 	graph["1"] = []interface{}{"1"}
 
-	output := Connections(graph)
+	o := Connections(graph)
+	output := sortConnections(o)
 	if output[0][0] != "1" {
 		t.FailNow()
 	}
@@ -169,14 +131,15 @@ func TestMultipleVertexLoop(t *testing.T) {
 	graph["2"] = []interface{}{"3"}
 	graph["3"] = []interface{}{"1"}
 
-	output := Connections(graph)
-	if output[0][0] != "3" {
+	o := Connections(graph)
+	output := sortConnections(o)
+	if output[0][0] != "1" {
 		t.FailNow()
 	}
 	if output[0][1] != "2" {
 		t.FailNow()
 	}
-	if output[0][2] != "1" {
+	if output[0][2] != "3" {
 		t.FailNow()
 	}
 }
@@ -192,9 +155,30 @@ func ExampleConnections() {
 	graph["7"] = []interface{}{"6"}
 	graph["8"] = []interface{}{"5", "7", "8"}
 
-	output := Connections(graph)
+	o := Connections(graph)
+	output := sortConnections(o)
 	fmt.Println(output)
 
 	// Output:
-	// [[3 2 1] [7 6] [5 4] [8]]
+	// [[1 2 3] [6 7] [4 5] [8]]
+}
+
+func sortConnections(connections [][]interface{}) [][]string {
+	out := make([][]string, 0, len(connections))
+	for _, cons := range connections {
+		slice := make([]string, 0, len(cons))
+		for _, v := range cons {
+			switch v := v.(type) {
+			case string:
+				slice = append(slice, v)
+			case int:
+				slice = append(slice, fmt.Sprintf("%d", v))
+			default:
+				panic(fmt.Errorf("invalid type [%T]", v))
+			}
+		}
+		sort.Strings(slice)
+		out = append(out, slice)
+	}
+	return out
 }


### PR DESCRIPTION
because maps are iterated in random order, we need to somehow stabilize the output of connections, at least for tests' sake.
